### PR TITLE
Clone oh-my-zsh with force=yes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   when: ansible_os_family == "Darwin"
 
 - name: Install oh-my-zsh
-  git: repo=https://github.com/robbyrussell/oh-my-zsh dest=~/.oh-my-zsh
+  git: repo=https://github.com/robbyrussell/oh-my-zsh dest=~/.oh-my-zsh force=yes
   sudo: no 
 
 - name: Back up existing ~/.zshrc


### PR DESCRIPTION
Prior to ansible 1.9 the git module was cloning with force true, so for users with ansible 1.9 and newer, a reprovision with this ansible role enabled fails, as modifications are made to the git repos later in the process (the custom theme).

I hope you will accept this pull-request and publish the changes to ansible galaxy, as this bug currently prevents me from actively using this nice zsh ansible role for my servers.
